### PR TITLE
fix: fix non const multiplication over k in Schnorr

### DIFF
--- a/btcec/common/common.go
+++ b/btcec/common/common.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"crypto/rand"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+func ScalarBaseMultWithBlinding(k *btcec.ModNScalar) (*btcec.JacobianPoint, error) {
+	// Generate a random blinding factor r
+	r := new(btcec.ModNScalar)
+	var rBytes [32]byte
+	if _, err := rand.Read(rBytes[:]); err != nil {
+		return nil, err
+	}
+	r.SetByteSlice(rBytes[:])
+
+	// Compute (k+r)G
+	kr := new(btcec.ModNScalar).Set(k).Add(r)
+	var krG btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(kr, &krG)
+
+	// Compute -rG
+	rNeg := new(btcec.ModNScalar).Set(r).Negate()
+	var rNegG btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(rNeg, &rNegG)
+
+	// Convert to affine coordinates so that the addition is constant time
+	krG.ToAffine()
+	rNegG.ToAffine()
+
+	// Add (k+r)G and -rG to get kG
+	var R btcec.JacobianPoint
+	btcec.AddNonConst(&krG, &rNegG, &R)
+
+	return &R, nil
+}

--- a/btcec/schnorr/signature.go
+++ b/btcec/schnorr/signature.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/common"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	ecdsa_schnorr "github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr"
@@ -284,10 +285,12 @@ func schnorrSign(privKey, nonce *btcec.ModNScalar, pubKey *btcec.PublicKey, hash
 	//
 	// Step 10.
 	//
-	// R = kG
-	var R btcec.JacobianPoint
+	// R = kG (with blinding in order to prevent timing side channel attacks)
 	k := *nonce
-	btcec.ScalarBaseMultNonConst(&k, &R)
+	R, err := common.ScalarBaseMultWithBlinding(&k)
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 11.
 	//


### PR DESCRIPTION
btcec implements Schnorr [itself](https://github.com/btcsuite/btcd/blob/v0.24.2/btcec/schnorr/signature.go#L248) without relying on dcrd. So in order to fix covenant we need to fix btcd rather than drcd